### PR TITLE
fix: avoid forcing blur when tabing out

### DIFF
--- a/src/vcf-date-range-picker-mixin.js
+++ b/src/vcf-date-range-picker-mixin.js
@@ -1241,7 +1241,6 @@ export const DateRangePickerMixin = (subclass) =>
             this._inputStartElement.focus();
           } else {
             this.close();
-            this.blur();
           }
         }
         break;


### PR DESCRIPTION
Fix #37 by avoiding forcing blur when tabing out of the end range input field