### PR TITLE
fix: fix remove preselected elements by id

### DIFF
--- a/src/vcf-date-range-picker-mixin.js
+++ b/src/vcf-date-range-picker-mixin.js
@@ -1148,13 +1148,13 @@ export const DateRangePickerMixin = (subclass) =>
   }
 
   removePreselectionById(id) {
-    var handler = e => {
-      if (e.detail.value) {
+    var handler = () => {
+      if (this.opened) {
         this._overlayContent.removePreselectionById(id);
       }
-      this.$.overlay.removeEventListener('opened-changed',handler);
+      this.$.overlay.removeEventListener('vaadin-overlay-open',handler);
     }
-    this.$.overlay.addEventListener('opened-changed', handler);
+    this.$.overlay.addEventListener('vaadin-overlay-open', handler);
   }
 
   /** @private */


### PR DESCRIPTION
This update is needed for https://github.com/vaadin-component-factory/vcf-date-range-picker-flow/issues/45.

Method `removePreselectionById` is supposed to be called when overlay opens. It was failing as the event being trigered when it opens is `vaadin-overlay-open` instead of `opened-changed`. So the method was not being called when needed. I think this feature was not taken in consideration when overlay updates were done on the big refactor done on the component to be compatible with vaadin 24 https://github.com/vaadin-component-factory/vcf-date-range-picker/pull/39/files.

Method removePreselectionById` is being called from server-side's method `removePresetByIds` mentioned in issue https://github.com/vaadin-component-factory/vcf-date-range-picker-flow/issues/45